### PR TITLE
Limit User Profile Editing to First 24 Hours

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -74,8 +74,11 @@ class UsersController < ApplicationController
     # Confirms the correct user.
     def correct_user
       @user = User.find(params[:id])
-      redirect_to(root_url, status: :see_other) unless current_user?(@user)
+      if Time.now - @user.created_at > 24.hours
+        flash[:danger] = "You can only edit your profile within 24 hours of account creation."
+      end
     end
+
 
     # Confirms an admin user.
     def admin_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -72,13 +72,14 @@ class UsersController < ApplicationController
     # Before filters
 
     # Confirms the correct user.
-    def correct_user
-      @user = User.find(params[:id])
-      if Time.now - @user.created_at > 24.hours
-        flash[:danger] = "You can only edit your profile within 24 hours of account creation."
-      end
+  def correct_user
+    @user = User.find(params[:id])
+    if Time.current - @user.created_at > 24.hours
+      flash[:danger] = "You can only edit your profile within 24 hours of account creation."
+      redirect_to(root_url, status: :see_other) and return
     end
-
+    redirect_to(root_url, status: :see_other) unless current_user?(@user) 
+  end
 
     # Confirms an admin user.
     def admin_user

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -38,6 +38,23 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_url
   end
 
+  test "should not allow the user to edit profile after 24 hours of account creation" do
+    @user.update(created_at: 2.days.ago)
+    log_in_as(@user)
+    get edit_user_path(@user)
+    assert_not flash.empty?
+    assert_equal "You can only edit your profile within 24 hours of account creation.", flash[:danger]
+    assert_redirected_to root_url
+  end
+
+  test "should allow the user to edit profile within 24 hours of account creation" do
+    @user.update(created_at: 1.hour.ago)
+    log_in_as(@user)
+    get edit_user_path(@user)
+    assert flash.empty?
+    assert_response :success
+  end
+
   test "should redirect update when logged in as wrong user" do
     log_in_as(@other_user)
     patch user_path(@user), params: { user: { name: @user.name,


### PR DESCRIPTION
This pull request introduces a change to the `correct_user` method in the UsersController to limit the time frame in which a user can edit their profile to the first 24 hours after account creation.

Changes include:

Added a condition in `correct_user` method to check if the current time is more than 24 hours from the time of account creation.
If the condition is met, a flash message is displayed informing the user that they can only edit their profile within 24 hours of account creation, and they are redirected to the root URL.
This change is intended to enhance account security by reducing the window in which a user's profile can be edited. It will be particularly effective in limiting the potential damage if a user's account is compromised.

Please review and provide any feedback.