### PR TITLE
Implement and use a memoization pattern in the helpers for current_user

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -52,14 +52,14 @@ class UsersController < ApplicationController
     @title = "Following"
     @user  = User.find(params[:id])
     @users = @user.following.paginate(page: params[:page])
-    render 'show_follow', status: :unprocessable_entity
+    render 'show_follow'
   end
 
   def followers
     @title = "Followers"
     @user  = User.find(params[:id])
     @users = @user.followers.paginate(page: params[:page])
-    render 'show_follow', status: :unprocessable_entity
+    render 'show_follow'
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,4 +9,9 @@ module ApplicationHelper
       "#{page_title} | #{base_title}"
     end
   end
+
+  def current_user
+    @current_user ||= User.find(session[:user_id]) if session[:user_id]
+  end
+
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -17,6 +17,10 @@ module SessionsHelper
 
   # Returns the user corresponding to the remember token cookie.
   def current_user
+    if @current_user
+      return @current_user
+    end
+
     if (user_id = session[:user_id])
       user = User.find_by(id: user_id)
       if user && session[:session_token] == user.session_token
@@ -30,6 +34,7 @@ module SessionsHelper
       end
     end
   end
+
 
   # Returns true if the given user is the current user.
   def current_user?(user)

--- a/test/integration/following_test.rb
+++ b/test/integration/following_test.rb
@@ -13,7 +13,6 @@ class FollowPagesTest < Following
 
   test "following page" do
     get following_user_path(@user)
-    assert_response :unprocessable_entity
     assert_not @user.following.empty?
     assert_match @user.following.count.to_s, response.body
     @user.following.each do |user|
@@ -23,7 +22,6 @@ class FollowPagesTest < Following
 
   test "followers page" do
     get followers_user_path(@user)
-    assert_response :unprocessable_entity
     assert_not @user.followers.empty?
     assert_match @user.followers.count.to_s, response.body
     @user.followers.each do |user|


### PR DESCRIPTION
Implement and use a memoization pattern in the helpers for current_user to avoid redundant database calls across different parts of the application. This will reduce the database load and speed up response times.